### PR TITLE
Update warning banner text

### DIFF
--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -22,10 +22,10 @@ const Layout: React.FC<any> = ({ children }) => {
   return (
     <>
       <APRWarning>
-        Please be advised that $PNG farming rewards have ceased and the APRs shown are inaccurate. Pangolin V3 will be
-        launching soon.{' '}
-        <APRWarningLink href="https://x.com/pangolindex/status/1788647901607985647" target="_blank" rel="noreferrer">
-          See more details here
+      Please be advised that $PNG has reached its final circulating supply of 230 million and standard farms are no longer in force or emitting PNG rewards.
+          We invite you to visit our new app, currently in Beta, to discover any ongoing SuperFarms. These are temporary farms that issue dual rewards.{' '}
+          <APRWarningLink href="https://beta.pangolin.exchange/superfarmsv2" target="_blank" rel="noreferrer">
+            Explore SuperFarms
         </APRWarningLink>
         .
       </APRWarning>


### PR DESCRIPTION
Revised the warning banner message to reflect the final circulating supply of $PNG and the discontinuation of standard farms. Updated the link and text to direct users to SuperFarms on the Beta app. No functional changes were made.