### PR TITLE
Add News Channel link to the menu

### DIFF
--- a/src/layout/Header/MenuItems.tsx
+++ b/src/layout/Header/MenuItems.tsx
@@ -4,23 +4,26 @@ import { LaunchAppButton } from 'src/components/LaunchAppButton'
 
 export default function MenuItems() {
   return (
-    <Links>
-      <Link href="https://docs.pangolin.exchange/intro/dao" id="menu-about-dao">
-        About DAO
-      </Link>
-      <Link href="https://app.pangolin.exchange" id="menu-exchange">
-        Exchange
-      </Link>
-      <Link href="https://info.pangolin.exchange/" id="menu-analytics">
-        Analytics
-      </Link>
-      <Link href="https://docs.pangolin.exchange/" id="menu-docs">
-        Docs
-      </Link>
-      {/* <Link variant="primary" href="https://app.pangolin.exchange" id="menu-launch-app">
-        Launch App
-      </Link> */}
-      <LaunchAppButton />
-    </Links>
+<Links>
+  <Link href="https://docs.pangolin.exchange/intro/dao" id="menu-about-dao">
+    About DAO
+  </Link>
+  <Link href="https://app.pangolin.exchange" id="menu-exchange">
+    Exchange
+  </Link>
+  <Link href="https://info.pangolin.exchange/" id="menu-analytics">
+    Analytics
+  </Link>
+  <Link href="https://docs.pangolin.exchange/" id="menu-docs">
+    Docs
+  </Link>
+  <Link href="https://t.me/pangolindex" id="menu-news">
+    News Channel
+  </Link>
+  {/* <Link variant="primary" href="https://app.pangolin.exchange" id="menu-launch-app">
+    Launch App
+  </Link> */}
+  <LaunchAppButton />
+</Links>
   )
 }


### PR DESCRIPTION
Added a new link to the navigation menu for the Pangolindex News Channel, which redirects to the Telegram channel at https://t.me/pangolindex. The link has been assigned the ID menu-news. This update provides users quick access to the latest updates and announcements via Telegram.